### PR TITLE
[JR-AVL-987] Adicionado opção de token como autenticação

### DIFF
--- a/lib/convert_api/client.rb
+++ b/lib/convert_api/client.rb
@@ -101,10 +101,10 @@ module ConvertApi
     end
 
     def request_uri(path, params = {})
-      raise(SecretError, 'API secret not configured') if config.api_secret.nil?
+      raise(TokenError, 'Token not configured') if config.token.nil?
 
-      params_with_secret = params.merge(Secret: config.api_secret)
-      query = URI.encode_www_form(params_with_secret)
+      params_with_token = params.merge(Token: config.token)
+      query = URI.encode_www_form(params_with_token)
 
       base_uri.path + path + '?' + query
     end

--- a/lib/convert_api/configuration.rb
+++ b/lib/convert_api/configuration.rb
@@ -1,6 +1,7 @@
 module ConvertApi
   class Configuration
     attr_accessor :api_secret
+    attr_accessor :token
     attr_accessor :base_uri
     attr_accessor :connect_timeout
     attr_accessor :read_timeout

--- a/lib/convert_api/errors.rb
+++ b/lib/convert_api/errors.rb
@@ -1,6 +1,7 @@
 module ConvertApi
   class Error < StandardError; end
   class SecretError < Error; end
+  class TokenError < Error; end
   class FileNameError < Error; end
   class TimeoutError < Error; end
   class ConnectionFailed < Error; end

--- a/spec/convert_api_spec.rb
+++ b/spec/convert_api_spec.rb
@@ -10,15 +10,18 @@ RSpec.describe ConvertApi do
 
   describe '.configure' do
     let(:api_secret) { 'test_secret' }
+    let(:token) { 'test_token' }
     let(:conversion_timeout) { 20 }
 
     it 'configures' do
       described_class.configure do |config|
         config.api_secret = api_secret
+        config.token = token
         config.conversion_timeout = conversion_timeout
       end
 
       expect(described_class.config.api_secret).to eq(api_secret)
+      expect(described_class.config.token).to eq(token)
       expect(described_class.config.conversion_timeout).to eq(conversion_timeout)
     end
   end
@@ -89,11 +92,11 @@ RSpec.describe ConvertApi do
       it_behaves_like 'successful conversion'
     end
 
-    context 'when secret is not set' do
-      before { ConvertApi.config.api_secret = nil }
+    context 'when token is not set' do
+      before { ConvertApi.config.token = nil }
 
       it 'raises error' do
-        expect { subject }.to raise_error(ConvertApi::SecretError, /not configured/)
+        expect { subject }.to raise_error(ConvertApi::TokenError, /not configured/)
       end
     end
 


### PR DESCRIPTION
For use the `token` instead of the `api_secret`