### PR TITLE
Switch to authorization header

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,5 +24,4 @@ jobs:
       - run: bundle install
       - env:
           CONVERT_API_SECRET: ${{ secrets.CONVERTAPI_SECRET }}
-          CONVERT_API_TOKEN: ${{ secrets.CONVERTAPI_TOKEN }}
         run: bundle exec rake spec

--- a/README.md
+++ b/README.md
@@ -23,20 +23,11 @@ gem 'convert_api'
 
 ### Configuration
 
-You can get your secret at https://www.convertapi.com/a/auth
+You can get your credentials at https://www.convertapi.com/a/auth
 
 ```ruby
 ConvertApi.configure do |config|
-  config.api_secret = 'your-api-secret'
-end
-```
-
-Or
-
-You can get your token at https://www.convertapi.com/a/access-tokens
-```ruby
-ConvertApi.configure do |config|
-  config.token = 'your-token'
+  config.api_credentials = 'your-api-secret-or-token'
 end
 ```
 
@@ -135,10 +126,6 @@ Find more advanced examples in the [examples/](https://github.com/ConvertAPI/con
 ## Development
 
 Run `CONVERT_API_SECRET=your_secret rake spec` to run the tests.
-
-Or
-
-Run `CONVERT_API_TOKEN=your_token rake spec` to run the tests.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/examples/conversions_chaining.rb
+++ b/examples/conversions_chaining.rb
@@ -2,9 +2,7 @@ require 'convert_api'
 require 'tmpdir'
 
 ConvertApi.configure do |config|
-  config.api_secret = ENV['CONVERT_API_SECRET'] # your api secret
-  # or
-  config.token = ENV['CONVERT_API_TOKEN'] # your token
+  config.api_credentials = ENV['CONVERT_API_SECRET'] # your api secret or token
 end
 
 # Short example of conversions chaining, the PDF pages extracted and saved as separated JPGs and then ZIP'ed

--- a/examples/convert_stream.rb
+++ b/examples/convert_stream.rb
@@ -2,9 +2,7 @@ require 'convert_api'
 require 'tmpdir'
 
 ConvertApi.configure do |config|
-  config.api_secret = ENV['CONVERT_API_SECRET'] # your api secret
-  # or
-  config.token = ENV['CONVERT_API_TOKEN'] # your token
+  config.api_credentials = ENV['CONVERT_API_SECRET'] # your api secret or token
 end
 
 # Example of converting text to PDF

--- a/examples/convert_url_to_pdf.rb
+++ b/examples/convert_url_to_pdf.rb
@@ -2,10 +2,9 @@ require 'convert_api'
 require 'tmpdir'
 
 ConvertApi.configure do |config|
-  config.api_secret = ENV['CONVERT_API_SECRET'] # your api secret
-  # or
-  config.token = ENV['CONVERT_API_TOKEN'] # your token
+  config.api_credentials = ENV['CONVERT_API_SECRET'] # your api secret or token
 end
+
 # Example of converting Web Page URL to PDF file
 # https://www.convertapi.com/web-to-pdf
 

--- a/examples/convert_word_to_pdf_and_png.rb
+++ b/examples/convert_word_to_pdf_and_png.rb
@@ -2,9 +2,7 @@ require 'convert_api'
 require 'tmpdir'
 
 ConvertApi.configure do |config|
-  config.api_secret = ENV['CONVERT_API_SECRET'] # your api secret
-  # or
-  config.token = ENV['CONVERT_API_TOKEN'] # your token
+  config.api_credentials = ENV['CONVERT_API_SECRET'] # your api secret or token
 end
 
 # Example of saving Word docx to PDF and to PNG

--- a/examples/create_pdf_thumbnail.rb
+++ b/examples/create_pdf_thumbnail.rb
@@ -2,9 +2,7 @@ require 'convert_api'
 require 'tmpdir'
 
 ConvertApi.configure do |config|
-  config.api_secret = ENV['CONVERT_API_SECRET'] # your api secret
-  # or
-  config.token = ENV['CONVERT_API_TOKEN'] # your token
+  config.api_credentials = ENV['CONVERT_API_SECRET'] # your api secret or token
 end
 
 # Example of extracting first page from PDF and then chaining conversion PDF page to JPG.

--- a/examples/retrieve_user_information.rb
+++ b/examples/retrieve_user_information.rb
@@ -1,9 +1,7 @@
 require 'convert_api'
 
 ConvertApi.configure do |config|
-  config.api_secret = ENV['CONVERT_API_SECRET'] # your api secret
-  # or
-  config.token = ENV['CONVERT_API_TOKEN'] # your token
+  config.api_credentials = ENV['CONVERT_API_SECRET'] # your api secret or token
 end
 
 # Retrieve user information

--- a/examples/split_and_merge_pdf.rb
+++ b/examples/split_and_merge_pdf.rb
@@ -2,9 +2,7 @@ require 'convert_api'
 require 'tmpdir'
 
 ConvertApi.configure do |config|
-  config.api_secret = ENV['CONVERT_API_SECRET'] # your api secret
-  # or
-  config.token = ENV['CONVERT_API_TOKEN'] # your token
+  config.api_credentials = ENV['CONVERT_API_SECRET'] # your api secret or token
 end
 
 # Example of extracting first and last pages from PDF and then merging them back to new PDF.

--- a/lib/convert_api/configuration.rb
+++ b/lib/convert_api/configuration.rb
@@ -1,7 +1,6 @@
 module ConvertApi
   class Configuration
-    attr_accessor :api_secret
-    attr_accessor :token
+    attr_accessor :api_credentials
     attr_accessor :base_uri
     attr_accessor :connect_timeout
     attr_accessor :read_timeout

--- a/spec/convert_api_spec.rb
+++ b/spec/convert_api_spec.rb
@@ -9,19 +9,16 @@ RSpec.describe ConvertApi do
   end
 
   describe '.configure' do
-    let(:api_secret) { 'test_secret' }
-    let(:token) { 'test_token' }
+    let(:api_credentials) { 'test_secret' }
     let(:conversion_timeout) { 20 }
 
     it 'configures' do
       described_class.configure do |config|
-        config.api_secret = api_secret
-        config.token = token
+        config.api_credentials = api_credentials
         config.conversion_timeout = conversion_timeout
       end
 
-      expect(described_class.config.api_secret).to eq(api_secret)
-      expect(described_class.config.token).to eq(token)
+      expect(described_class.config.api_credentials).to eq(api_credentials)
       expect(described_class.config.conversion_timeout).to eq(conversion_timeout)
     end
   end
@@ -93,23 +90,14 @@ RSpec.describe ConvertApi do
     end
 
     context 'when has error' do
-      it 'raises error without secret or token' do
-        described_class.config.api_secret = nil
-        described_class.config.token = nil
+      it 'raises error without credentials' do
+        described_class.config.api_credentials = nil
 
         expect { subject }.to raise_error(ConvertApi::AuthenticationError, /not configured/)
       end
 
-      it 'with invalid secret' do
-        described_class.config.api_secret = 'invalid'
-        described_class.config.token = nil
-
-        expect { subject }.to raise_error(ConvertApi::ClientError)
-      end
-
-      it 'with invalid token' do
-        described_class.config.token = 'invalid'
-        described_class.config.api_secret = nil
+      it 'with invalid credentials' do
+        described_class.config.api_credentials = 'invalid'
 
         expect { subject }.to raise_error(ConvertApi::ClientError)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,8 +9,6 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
-    ConvertApi.config.api_secret = ENV['CONVERT_API_SECRET']
-    # or
-    ConvertApi.config.token = ENV['CONVERT_API_TOKEN']
+    ConvertApi.config.api_credentials = ENV['CONVERT_API_SECRET']
   end
 end


### PR DESCRIPTION
Will pass authorization bearer header instead of params. 
Also renaming `api_secret` to `api_credentials`, because it accepts both secret and token.

https://github.com/ConvertAPI/convertapi-library-python/issues/48